### PR TITLE
Add CI make targets to run tests and benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,37 @@ benchmarks: $(BENCH_BINARIES)
 .PHONY: complete
 complete: asm wrappers tests benchmarks
 
+# Run all compiled tests sequentially
+.PHONY: run-tests
+run-tests: tests
+	@if [ -z "$(TEST_BINARIES)" ]; then \
+		echo "No test binaries defined."; \
+	else \
+		set -e; \
+		for exe in $(TEST_BINARIES); do \
+			echo "Running $$exe"; \
+			"$$exe"; \
+			done; \
+	fi
+
+# Run all compiled benchmarks sequentially
+.PHONY: run-benchmarks
+run-benchmarks: benchmarks
+	@if [ -z "$(BENCH_BINARIES)" ]; then \
+		echo "No benchmark binaries defined."; \
+	else \
+		set -e; \
+		for exe in $(BENCH_BINARIES); do \
+			echo "Running $$exe"; \
+			"$$exe"; \
+			done; \
+	fi
+
+# Clean build, rebuild everything, and execute tests and benchmarks
+.PHONY: ci
+ci: clean complete run-tests run-benchmarks
+	@echo "CI pipeline completed successfully."
+
 # Assembly compilation rule
 $(BUILD_OBJ)/%.o: $(SRC_ASM)/%.asm | dirs
 	@echo "Assembling $<..."

--- a/README.md
+++ b/README.md
@@ -180,22 +180,30 @@ All functions documented in [`include/fp_core.h`](include/fp_core.h) with:
 ## 🛠️ Build Instructions
 
 ### Requirements
-- **Assembler**: NASM (for Windows x64)
-- **Compiler**: GCC (MinGW64) or Clang
-- **Platform**: Windows x64 (Linux port planned)
+- **Assembler**: NASM (x86_64)
+- **Compiler**: GCC or Clang with AVX2 support
+- **Build tooling**: GNU Make
+- **Platform**: Linux x86_64 (Windows build scripts remain available under `*.bat`)
 
-### Compile & Test
+### Build & Validate
 
 ```bash
-# Assemble a module
-nasm -f win64 src/asm/fp_core_reductions.asm -o build/obj/fp_core_reductions.o
+# Build everything (assembly, wrappers, tests, benchmarks)
+make complete
 
-# Run general HOF tests
-build_test_general_hof.bat
+# Execute every test binary that was just built
+make run-tests
 
-# Run performance benchmarks
-build_bench_general_hof.bat
+# Execute every benchmark binary that was just built
+make run-benchmarks
+
+# Rebuild from scratch and run tests + benchmarks in one step
+make ci
 ```
+
+> **Note:** The 3D benchmark currently reports warning-level diagnostics for
+> large-N dot products due to expected fused-multiply-add drift. The run still
+> completes successfully and is included in `make run-benchmarks` and `make ci`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add `run-tests`, `run-benchmarks`, and `ci` convenience targets to the Makefile so the full build, test, and benchmark matrix can be exercised with one command
- document the new Linux-oriented workflow and commands in the README, including the existing numerical warning emitted by the 3D benchmark

## Testing
- make run-tests
- make run-benchmarks
- make ci

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917cbfda9ac8321913fc0efbc6eb45a)