### PR TITLE
fix: Use OAuth for Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,8 +35,8 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          # Using API key authentication - add ANTHROPIC_API_KEY to repo secrets
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Using OAuth token - run /install-github-app in Claude Code CLI to set up
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,8 +34,8 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          # Using API key authentication - add ANTHROPIC_API_KEY to repo secrets
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Using OAuth token - run /install-github-app in Claude Code CLI to set up
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary

Reverts Claude workflows to use OAuth token instead of API key.

OAuth is simpler for Claude Pro subscribers - no need for separate API billing.

## Setup Instructions

1. Run `/install-github-app` in Claude Code CLI
2. Follow prompts to authorize GitHub access
3. The token will be automatically configured as `CLAUDE_CODE_OAUTH_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)