### PR TITLE
fix: Grant full permissions to Claude review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,10 +20,11 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
+      actions: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Claude review workflow had read-only permissions, preventing it from posting PR comments.

## Changes

| Permission | Before | After |
|------------|--------|-------|
| contents | read | **write** |
| pull-requests | read | **write** |
| issues | read | **write** |
| actions | - | **write** |

Now Claude has the same capabilities as Codex for PR reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)