### PR TITLE
fix: Full write permissions for Claude workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,11 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Grant full write permissions to both Claude workflows.

## Final Permissions (both workflows):

| Permission | Value |
|------------|-------|
| contents | **write** |
| pull-requests | **write** |
| issues | **write** |
| id-token | write |
| actions | **write** |

Claude can now:
- ✅ Read and write files
- ✅ Comment on PRs and issues
- ✅ Create commits and branches
- ✅ Read CI/action results
- ✅ Equivalent to Codex permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)