### PR TITLE
Fix: Correct include path for fp_core.h in test_general_hof.c

### DIFF
--- a/tests/unit/test_general_hof.c
+++ b/tests/unit/test_general_hof.c
@@ -9,7 +9,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <math.h>
-#include "include/fp_core.h"
+#include "fp_core.h"
 
 // ============================================================================
 // FOLDL TEST FUNCTIONS


### PR DESCRIPTION
Updated the include directive to use fp_core.h instead of include/fp_core.h. This fixes compilation errors when using standard build flags like -I include.